### PR TITLE
fix ysFixWebmDuraion download format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 # Parcel related files
 dist/
 .cache/
+
+#vscode files
+.vscode/

--- a/src/scripts/script.ts
+++ b/src/scripts/script.ts
@@ -240,7 +240,7 @@ function stopRecording() {
   });
 
   ysFixWebmDuration(blob, duration, (fixed) => {
-    download(URL.createObjectURL(fixed), `recording_${+new Date()}.png`);
+    download(URL.createObjectURL(fixed), `recording_${+new Date()}.webm`);
   });
 }
 


### PR DESCRIPTION
This is a really simple change, from which it seems like the format I believe should be webm.

I tested with mp4 and it also works, but as the comments within the document suggests, I believe webm should be the format to go, rather than '.png'